### PR TITLE
Fixed duplication of symbols when the Advertiser SDK is used with the Publisher SDK.

### DIFF
--- a/Pod/Classes/Core/Components/ComponentModule.swift
+++ b/Pod/Classes/Core/Components/ComponentModule.swift
@@ -5,7 +5,7 @@
 //  Created by Gunhan Sancar on 04/04/2020.
 //
 
-@objc(SAComponentModuleType)
+@objc(SAAComponentModuleType)
 @available(*, deprecated, message: "Will be deleted")
 public protocol ComponentModuleObjcType {
     var device: DeviceType { get }

--- a/Pod/Classes/Core/Components/Device.swift
+++ b/Pod/Classes/Core/Components/Device.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@objc(SADeviceType)
+@objc(SAADeviceType)
 public protocol DeviceType {
     var type: String { get }
     var genericType: String { get }
@@ -16,7 +16,7 @@ public protocol DeviceType {
     var userAgent: String { get }
 }
 
-@objc(SADevice)
+@objc(SAADevice)
 class Device : NSObject, DeviceType {
     public var type: String
     public var genericType: String

--- a/Pod/Classes/Core/Components/UserAgent.swift
+++ b/Pod/Classes/Core/Components/UserAgent.swift
@@ -10,12 +10,12 @@ import WebKit
 /**
 * Class that returns the current User Agent using WKWebView object.
 */
-@objc(SAUserAgentType)
+@objc(SAAUserAgentType)
 public protocol UserAgentType {
     @objc(name) var name: String { get }
 }
 
-@objc(SAUserAgent)
+@objc(SAAUserAgent)
 public class UserAgent : NSObject, UserAgentType {
     public var name: String
     private var webView: WKWebView?

--- a/Pod/Classes/Core/DependencyContainerObj.swift
+++ b/Pod/Classes/Core/DependencyContainerObj.swift
@@ -5,7 +5,7 @@
 //  Created by Gunhan Sancar on 06/04/2020.
 //
 
-@objc(SADependencyContainer)
+@objc(SAADependencyContainer)
 @available(*, deprecated, message: "Will be deleted")
 public class DependencyContainerObj: NSObject {
     @objc(shared)

--- a/Pod/Classes/Core/ModuleContainer.swift
+++ b/Pod/Classes/Core/ModuleContainer.swift
@@ -5,7 +5,7 @@
 //  Created by Gunhan Sancar on 04/04/2020.
 //
 
-@objc(SAModuleContainerType)
+@objc(SAAModuleContainerType)
 @available(*, deprecated, message: "Will be deleted")
 public protocol ModuleContainerType {
     @objc(componentModule)
@@ -15,7 +15,7 @@ public protocol ModuleContainerType {
     var repositoryModule: RepositoryModuleObjcType { get }
 }
 
-@objc(SAModuleContainer)
+@objc(SAAModuleContainer)
 public class ModuleContainer: NSObject, ModuleContainerType {
     lazy public var repositoryModule: RepositoryModuleObjcType = RepositoryModuleObjc()
     lazy public var componentModule: ComponentModuleObjcType = ComponentModuleObjc(dataRepository: repositoryModule.dataRepository)

--- a/Pod/Classes/Core/Repositories/DataRepository.swift
+++ b/Pod/Classes/Core/Repositories/DataRepository.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-@objc(SADataRepositoryType)
+@objc(SAADataRepositoryType)
 public protocol DataRepositoryType {
     var userAgent: String? { get set }
 }
 
-@objc(SADataRepository)
+@objc(SAADataRepository)
 class DataRepository : NSObject, DataRepositoryType {
     struct Keys {
         internal static let userAgent = "SuperAwesome.DataRepository.Keys.UserAgent"

--- a/Pod/Classes/Core/Repositories/RepositoryModule.swift
+++ b/Pod/Classes/Core/Repositories/RepositoryModule.swift
@@ -5,7 +5,7 @@
 //  Created by Gunhan Sancar on 04/04/2020.
 //
 
-@objc(SARepositoryModuleType)
+@objc(SAARepositoryModuleType)
 @available(*, deprecated, message: "Will be deleted")
 public protocol RepositoryModuleObjcType {
     var dataRepository: DataRepositoryType { get }

--- a/Pod/Classes/SAAdvUtils.m
+++ b/Pod/Classes/SAAdvUtils.m
@@ -23,7 +23,7 @@
 }
 
 + (NSString*) getUserAgent {
-    return SADependencyContainer.shared.modules.componentModule.userAgent.name;
+    return SAADependencyContainer.shared.modules.componentModule.userAgent.name;
 }
 
 /**

--- a/Pod/Classes/SAInstall.m
+++ b/Pod/Classes/SAInstall.m
@@ -20,7 +20,7 @@
  */
 - (id) init {
     if (self = [super init]) {
-        [SADependencyContainer initModules: SAModuleContainer.new];
+        [SAADependencyContainer initModules: SAAModuleContainer.new];
     }
     
     return self;


### PR DESCRIPTION
## JIRA
n/a

## DESCRIPTION

When using the Advertiser SDK with the Publisher SDK you will get symbol duplication errors in the console.
To Fix this I have renamed the ObjC names of all the classes as they are duplicates of those in the publisher SDK.

## SCREENSHOTS
n/a